### PR TITLE
Wire helper clients to real transport, fix CI-breaking bugs, consolidate branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow installs Python dependencies, lints and type-checks the
+# package, and runs the test suite across several Python versions.
 
 name: Continuous integration
 
@@ -13,23 +14,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        # Track the Python versions Home Assistant currently supports.
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install aiohttp flake8 mypy
+        python -m pip install aiohttp flake8 mypy pytest
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 aionanoleaf --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 aionanoleaf --count --max-complexity=20 --max-line-length=150 --statistics
-    - name: Test with mypy 
+    - name: Type check with mypy
       run: |
         mypy aionanoleaf
+    - name: Test with pytest
+      run: |
+        pytest -q

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,18 +6,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint aiohttp
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        # Lint the package; tests/examples are excluded via .pylintrc intent.
+        pylint aionanoleaf

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -58,6 +58,15 @@ tests gave false confidence.
    3.11–3.13 and added a `pytest` step (CI previously never ran the tests);
    bumped version `0.3.1 → 0.4.0`; documented the helper clients in the README.
 
+8. **`pylint.yml` workflow.** This separate workflow ran
+   `pylint $(git ls-files '*.py')`, which lints test scaffolding too — contrary
+   to the `.pylintrc` `ignore=tests,examples` intent. It was already red on
+   `master` (the duplicate class triggered `E0102`). Scoped it to
+   `pylint aionanoleaf` (now 10.00/10) and modernised its matrix to 3.11–3.13.
+   Note: `setup.py` still declares `python_requires=">=3.8"` (the basic client
+   works there via `from __future__ import annotations`); only the CI test
+   matrix was modernised.
+
 ## Verification
 
 `pytest` (14 passed, incl. new `tests/test_nanoleaf_transport.py` which drives

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,71 @@
+# Consolidation & development notes — aionanoleaf
+
+This document records what was changed in this branch
+(`claude/ecstatic-clarke-FREgt`) and why, so the work can be reviewed later.
+
+## Goal
+
+"Merge all branches and take the idea as far as you can." The fork's intent is
+to extend `aionanoleaf` with per-panel and module-level control (Digital Twin,
+Effects, Layout/orientation, Rhythm) for use by the companion Home Assistant
+integration (`ha-nanoleaf`).
+
+## Branch reconciliation
+
+| Branch | Disposition |
+| --- | --- |
+| `master` | Baseline (most features). Already contained PR #1. |
+| `codex/find-and-fix-a-bug-in-codebase` (PR #1) | **Already merged** into `master` (retries, panels/touch, hardware version, `_build_anim`). Nothing further to take — it is the older upstream lineage and `master` supersedes it. |
+| `codex/review-fork-for-major-issues` (PR #2) | **Merged here.** Adds `conftest.py` (run async tests without the `pytest-asyncio` plugin) and drops the orphaned `asyncio_mode = "strict"` from `pyproject.toml`. |
+
+## The core problem found
+
+The helper modules (`EffectsClient`, `LayoutClient`, `RhythmClient`,
+`DigitalTwin`) were written against a client interface
+(`_get_json` / `_put_json` / `write_effect`) that the real `Nanoleaf` class
+**did not implement** — it only had `_request`. So every new feature worked in
+the unit tests (which use mocks) but would fail against real hardware. The unit
+tests gave false confidence.
+
+## Changes
+
+1. **Removed a dead, duplicate `Nanoleaf` class** in `nanoleaf.py`.
+   There were two `class Nanoleaf` definitions; the first (~70 lines) referenced
+   attributes that don't exist (`self._base`, `self._token`) and was shadowed by
+   the second. It broke `flake8` (`F811`) and `mypy`, so **CI was red**. Removed
+   it; kept the real class.
+
+2. **Wired the helper clients to the real transport.** Added `Nanoleaf._get_json`,
+   `Nanoleaf._put_json` and `Nanoleaf.write_effect`, all built on the existing
+   `_request` (so they inherit auth, retries and error handling). The helper
+   clients and Digital Twin now work against a real device, not just mocks.
+
+3. **Fixed `DigitalTwin.create()` against a real device.** `Nanoleaf.panels`
+   returns a `set`, but `_get_object_positions` only accepted `list`/`tuple`, so
+   layout discovery silently failed. Now accepts `set`/`frozenset` too.
+
+4. **Wired in IPv6 host support.** `_format_host_for_url` existed but was unused;
+   `_api_url` now uses it, so IPv6 literals are bracketed correctly.
+
+5. **Fixed a touch-stream bug** in `events.py`: `2 ^ 16` (bitwise XOR → 18) was
+   meant to be the 16-bit "no second panel" sentinel; corrected to `0xFFFF`.
+
+6. **Exported `EffectsClient`** from the package (it was usable only via internal
+   import).
+
+7. **Tooling/packaging:** added `[tool.mypy]` config (tolerates the optional
+   `aiohttp` import in lint-only environments); modernised CI to Python
+   3.11–3.13 and added a `pytest` step (CI previously never ran the tests);
+   bumped version `0.3.1 → 0.4.0`; documented the helper clients in the README.
+
+## Verification
+
+`pytest` (14 passed, incl. new `tests/test_nanoleaf_transport.py` which drives
+the helper clients and Digital Twin through a fake `aiohttp` session),
+`flake8` (clean) and `mypy` (clean) all pass locally.
+
+## Deliberately NOT done
+
+- No behavioural change to `authorize()` — the HA `config_flow` depends on its
+  current exception contract (`Unauthorized` / `Unavailable`).
+- No hard dependency added on `pytest-asyncio` (the conftest covers both cases).

--- a/README.md
+++ b/README.md
@@ -58,3 +58,37 @@ await twin.set_all_colors((0,0,0))
 await twin.sync(transition_ms=100)       # builds & PUTs static scene
 colors = twin.colors                     # dict view {id: (r,g,b)}
 ```
+
+The `DigitalTwin`, `EffectsClient`, `LayoutClient` and `RhythmClient` helpers all
+talk to the device through the same authenticated `Nanoleaf` transport, so you
+can hand them a configured `Nanoleaf` instance directly.
+
+## Effects
+```python
+from aionanoleaf import EffectsClient
+
+effects = EffectsClient(light)
+names = await effects.get_effects_list()      # GET /effects/effectsList
+current = await effects.get_selected_effect() # GET /effects/select
+await effects.select_effect(names[0])         # PUT /effects {"select": ...}
+await effects.write_custom_effect("My FX", anim_data)  # add + select
+```
+
+## Layout / orientation
+```python
+from aionanoleaf import LayoutClient
+
+layout = LayoutClient(light)
+positions = await layout.get_positions()            # [{"panelId", "x", "y"}, ...]
+angle = await layout.get_global_orientation()        # int degrees (0..360)
+await layout.set_global_orientation(180)
+```
+
+## Rhythm / audio module
+```python
+from aionanoleaf import RhythmClient
+
+rhythm = RhythmClient(light)
+if await rhythm.is_active():
+    await rhythm.set_mode("aux")  # or "microphone" / 0 / 1
+```

--- a/aionanoleaf/__init__.py
+++ b/aionanoleaf/__init__.py
@@ -16,6 +16,7 @@
 # along with aionanoleaf.  If not, see <https://www.gnu.org/licenses/>.
 
 """aioNanoleaf."""
+from .effects import EffectsClient  # noqa: F401
 from .layout import LayoutClient  # noqa: F401
 from .rhythm import RhythmClient  # noqa: F401
 from .events import *  # noqa: F401, F403

--- a/aionanoleaf/digital_twin.py
+++ b/aionanoleaf/digital_twin.py
@@ -151,7 +151,9 @@ def _get_object_positions(nl: Any) -> List[_Panel]:
     """Fallback: infer from nl.panels/_panels objects with id/x/y attributes."""
     candidates = getattr(nl, "panels", None) or getattr(nl, "_panels", None)
     panels: List[_Panel] = []
-    if not isinstance(candidates, (list, tuple)):
+    # ``Nanoleaf.panels`` returns a ``set`` of Panel objects, so accept any
+    # (non-string) collection here, not just list/tuple.
+    if not isinstance(candidates, (list, tuple, set, frozenset)):
         return panels
 
     for obj in candidates:

--- a/aionanoleaf/events.py
+++ b/aionanoleaf/events.py
@@ -193,7 +193,10 @@ class TouchStreamEvent:
 
     @property
     def panel_id_2(self) -> int | None:
-        """Return second panel ID."""
-        if self._panel_id_2 == 2 ^ 16:
+        """Return second panel ID, or None when there is no paired panel."""
+        # The panel ID is a 16-bit field; an all-ones value (0xFFFF) is the
+        # protocol sentinel for "no second panel". The previous ``2 ^ 16``
+        # was a bitwise-XOR typo that evaluated to 18.
+        if self._panel_id_2 == 0xFFFF:
             return None
         return self._panel_id_2

--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -23,7 +23,7 @@ import asyncio
 import json
 import logging
 import socket
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from aiohttp import (
     ClientConnectorError,
@@ -55,80 +55,6 @@ from .typing import InfoData
 
 _LOGGER = logging.getLogger(__name__)
 
-class Nanoleaf:  # existing class
-    async def authorize(self) -> Optional[str]:
-        """Obtain a token while device is in link mode.
-
-        Tries POST /api/v1/new (classic) then GET /api/v1/new (newer fw).
-        Logs status + short body preview at DEBUG and accepts multiple JSON shapes.
-        """
-        url = f"{self._base}/new"
-
-        def _extract_token(obj: Any) -> Optional[str]:
-            if isinstance(obj, dict):
-                for k in ("auth_token", "authToken", "token"):
-                    v = obj.get(k)
-                    if isinstance(v, str):
-                        return v
-                succ = obj.get("success")
-                if isinstance(succ, dict):
-                    for k in ("auth_token", "authToken", "token"):
-                        v = succ.get(k)
-                        if isinstance(v, str):
-                            return v
-            elif isinstance(obj, list):
-                for item in obj:
-                    tok = _extract_token(item)
-                    if tok:
-                        return tok
-            return None
-
-        async def _try_post() -> Optional[str]:
-            import aiohttp
-            try:
-                payload = {"client_name": "homeassistant", "client_version": "1.0"}
-                async with self._session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                    text = await resp.text()
-                    _LOGGER.debug("authorize(POST): %s -> %s; body=%s", url, resp.status, text[:256])
-                    if resp.status == 200:
-                        try:
-                            data = json.loads(text)
-                        except Exception:
-                            data = None
-                        tok = _extract_token(data)
-                        if tok:
-                            self._token = tok
-                            return tok
-                    if resp.status in (401, 403):
-                        raise RuntimeError("Pairing not enabled (hold power 5–7s).")
-            except Exception as exc:
-                _LOGGER.debug("authorize(POST): exception: %s", exc)
-            return None
-
-        async def _try_get() -> Optional[str]:
-            import aiohttp
-            async with self._session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                text = await resp.text()
-                _LOGGER.debug("authorize(GET):  %s -> %s; body=%s", url, resp.status, text[:256])
-                if resp.status == 200:
-                    try:
-                        data = json.loads(text)
-                    except Exception:
-                        data = None
-                    tok = _extract_token(data)
-                    if tok:
-                        self._token = tok
-                        return tok
-                if resp.status in (401, 403):
-                    raise RuntimeError("Pairing not enabled (hold power 5–7s).")
-                raise RuntimeError(f"Authorization failed: {resp.status} {text[:256]}")
-
-        token = await _try_post()
-        if token:
-            return token
-        return await _try_get()
-
-
 
 def _format_host_for_url(host: str) -> str:
     """Return host formatted for http URLs; wrap bare IPv6 literals in [].
@@ -146,9 +72,6 @@ def _format_host_for_url(host: str) -> str:
     if ":" in h and re.fullmatch(r"[0-9A-Fa-f:]+", h):
         return f"[{h}]"
     return h
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Nanoleaf:
@@ -313,7 +236,7 @@ class Nanoleaf:
 
     @property
     def _api_url(self) -> str:
-        return f"http://{self.host}:{self.port}/api/v1"
+        return f"http://{_format_host_for_url(self.host)}:{self.port}/api/v1"
 
     async def _request(
         self, method: str, path: str, data: dict | None = None
@@ -351,6 +274,41 @@ class Nanoleaf:
             raise InvalidToken
         resp.raise_for_status()
         return resp
+
+    async def _get_json(self, path: str) -> Any:
+        """GET ``path`` (relative to the auth root) and return parsed JSON.
+
+        ``path`` may be given with or without a leading slash, e.g.
+        ``"/effects/select"`` or ``"panelLayout/layout"``. This is the
+        transport used by the helper clients (:class:`~aionanoleaf.effects.
+        EffectsClient`, :class:`~aionanoleaf.layout.LayoutClient` and
+        :class:`~aionanoleaf.rhythm.RhythmClient`).
+        """
+        resp = await self._request("get", path.lstrip("/"))
+        return await resp.json(content_type=None)
+
+    async def _put_json(self, path: str, body: dict | None = None) -> Any:
+        """PUT ``body`` as JSON to ``path``; return parsed JSON if any.
+
+        Many Nanoleaf write endpoints answer with ``204 No Content`` (or an
+        empty body), in which case ``None`` is returned.
+        """
+        resp = await self._request("put", path.lstrip("/"), body)
+        if resp.status == 204 or resp.content_length == 0:
+            return None
+        try:
+            return await resp.json(content_type=None)
+        except ValueError:  # empty or non-JSON body
+            return None
+
+    async def write_effect(self, write_dict: dict) -> None:
+        """Write (and optionally select) an effect via ``PUT /effects``.
+
+        ``write_dict`` is the inner ``write`` command payload, e.g. the
+        ``{"command": "display", "animType": "static", ...}`` dict built by
+        :class:`~aionanoleaf.digital_twin.DigitalTwin`.
+        """
+        await self._put_json("effects", {"write": dict(write_dict)})
 
     async def authorize(self) -> None:
         """

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,44 @@
+"""Minimal async test support for pytest without external plugin."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ``asyncio`` marker so ``--strict-markers`` works."""
+    config.addinivalue_line("markers", "asyncio: mark test as requiring an asyncio event loop")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Run ``async def`` tests using ``asyncio.run`` semantics.
+
+    This mirrors the default behaviour of the ``pytest-asyncio`` plugin for the
+    simple cases we have in this project without introducing an extra
+    dependency.
+    """
+
+    test_func = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_func):
+        return None
+
+    marker = pyfuncitem.get_closest_marker("asyncio")
+    if marker is None:
+        # Let pytest's normal handling complain about missing plugin if a test
+        # is a coroutine but not marked appropriately.
+        return None
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(test_func(**pyfuncitem.funcargs))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+    # Returning True tells pytest we executed the test ourselves.
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,3 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
-asyncio_mode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,12 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+
+[tool.mypy]
+python_version = "3.11"
+
+# ``aiohttp`` is an optional/runtime dependency whose type information is not
+# always resolvable in the lint environment; don't fail the type check on it.
+[[tool.mypy.overrides]]
+module = ["aiohttp", "aiohttp.*"]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="aionanoleaf",
-    version="0.3.1",
+    version="0.4.0",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",
     description="Async Python package for the Nanoleaf API",

--- a/tests/test_nanoleaf_transport.py
+++ b/tests/test_nanoleaf_transport.py
@@ -1,0 +1,246 @@
+# Copyright 2021, Milan Meulemans.
+#
+# This file is part of aionanoleaf.
+#
+# aionanoleaf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# aionanoleaf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with aionanoleaf.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Transport-level tests.
+
+These exercise the JSON helpers (``_get_json``/``_put_json``/``write_effect``)
+that wire the high-level helper clients (:class:`EffectsClient`,
+:class:`LayoutClient`, :class:`RhythmClient`, :class:`DigitalTwin`) to the real
+:class:`Nanoleaf` HTTP transport, using a fake ``aiohttp`` session so no real
+device is required.
+"""
+
+import json
+
+try:
+    import pytest  # type: ignore
+except ImportError:  # pragma: no cover - lint-only environments
+    pytest = None  # type: ignore
+
+from aionanoleaf import (
+    DigitalTwin,
+    EffectsClient,
+    LayoutClient,
+    Nanoleaf,
+    RhythmClient,
+)
+
+TOKEN = "tok123"
+
+
+def _loads(data):
+    """Decode the JSON string ``Nanoleaf._request`` passes to the session."""
+    if data is None:
+        return None
+    try:
+        return json.loads(data)
+    except (TypeError, ValueError):
+        return data
+
+
+class FakeResponse:
+    """Minimal stand-in for ``aiohttp.ClientResponse``."""
+
+    def __init__(self, status=200, payload=None, content_length=None):
+        self.status = status
+        self._payload = payload
+        self.content_length = content_length
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise AssertionError(f"unexpected HTTP {self.status}")
+
+    async def json(self, content_type=None):  # noqa: D401 - mimic aiohttp
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+_NO_CONTENT = lambda: FakeResponse(status=204, content_length=0)  # noqa: E731
+
+
+class FakeSession:
+    """Record requests and serve canned responses keyed by (method, path)."""
+
+    def __init__(self, routes):
+        self._routes = routes
+        self.calls = []
+
+    async def request(self, method, url, data=None, timeout=None):
+        path = url.split(f"/{TOKEN}/", 1)[1]
+        self.calls.append((method.lower(), path, _loads(data)))
+        factory = self._routes[(method.lower(), path)]
+        return factory()
+
+    def last(self, method, path):
+        for m, p, body in reversed(self.calls):
+            if m == method and p == path:
+                return body
+        raise AssertionError(f"no {method} {path} call recorded")
+
+
+def _make(routes):
+    session = FakeSession(routes)
+    return Nanoleaf(session, "10.0.0.5", TOKEN), session
+
+
+# --------------------------------------------------------------------------- #
+# URL formatting
+# --------------------------------------------------------------------------- #
+
+
+def test_api_url_plain_host():
+    nl = Nanoleaf(FakeSession({}), "192.168.0.10", TOKEN)
+    assert nl._api_url == "http://192.168.0.10:16021/api/v1"
+
+
+def test_api_url_wraps_ipv6_literal():
+    nl = Nanoleaf(FakeSession({}), "fe80::1", TOKEN)
+    assert nl._api_url == "http://[fe80::1]:16021/api/v1"
+
+
+# --------------------------------------------------------------------------- #
+# JSON transport helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_get_json_returns_payload():
+    nl, _ = _make({("get", "effects/select"): lambda: FakeResponse(payload="Nemo")})
+    assert await nl._get_json("/effects/select") == "Nemo"
+
+
+@pytest.mark.asyncio
+async def test_put_json_handles_no_content():
+    nl, session = _make({("put", "state"): _NO_CONTENT})
+    assert await nl._put_json("state", {"on": {"value": True}}) is None
+    assert session.last("put", "state") == {"on": {"value": True}}
+
+
+@pytest.mark.asyncio
+async def test_write_effect_wraps_payload_and_targets_effects():
+    nl, session = _make({("put", "effects"): _NO_CONTENT})
+    await nl.write_effect({"command": "display", "animType": "static"})
+    assert session.last("put", "effects") == {
+        "write": {"command": "display", "animType": "static"}
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Helper clients against the real transport
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_effects_client_through_real_transport():
+    nl, session = _make(
+        {
+            ("get", "effects/effectsList"): lambda: FakeResponse(payload=["A", "B"]),
+            ("get", "effects/select"): lambda: FakeResponse(payload="B"),
+            ("put", "effects"): _NO_CONTENT,
+        }
+    )
+    client = EffectsClient(nl)
+    assert await client.get_effects_list() == ["A", "B"]
+    assert await client.get_selected_effect() == "B"
+    await client.select_effect("A")
+    assert session.last("put", "effects") == {"select": "A"}
+
+
+@pytest.mark.asyncio
+async def test_layout_client_through_real_transport():
+    nl, session = _make(
+        {
+            ("get", "panelLayout/globalOrientation"): lambda: FakeResponse(
+                payload={"value": 90}
+            ),
+            ("put", "panelLayout/globalOrientation"): _NO_CONTENT,
+        }
+    )
+    client = LayoutClient(nl)
+    assert await client.get_global_orientation() == 90
+    await client.set_global_orientation(180)
+    assert session.last("put", "panelLayout/globalOrientation") == {"value": 180}
+
+
+@pytest.mark.asyncio
+async def test_rhythm_client_through_real_transport():
+    nl, session = _make(
+        {
+            ("get", "rhythm"): lambda: FakeResponse(
+                payload={"rhythmActive": True, "rhythmMode": 0}
+            ),
+            ("put", "rhythm"): _NO_CONTENT,
+        }
+    )
+    client = RhythmClient(nl)
+    assert await client.is_active() is True
+    assert await client.get_mode() == 0
+    await client.set_mode("aux")
+    assert session.last("put", "rhythm") == {"rhythmMode": 1}
+
+
+# --------------------------------------------------------------------------- #
+# Digital twin end-to-end against the real transport
+# --------------------------------------------------------------------------- #
+
+
+def _full_info(position_data):
+    return {
+        "name": "Shapes ABCD",
+        "serialNo": "SN123",
+        "manufacturer": "Nanoleaf",
+        "firmwareVersion": "7.0.0",
+        "hardwareVersion": "3.0",
+        "model": "NL42",
+        "state": {
+            "on": {"value": True},
+            "brightness": {"value": 50, "max": 100, "min": 0},
+            "hue": {"value": 120, "max": 360, "min": 0},
+            "sat": {"value": 80, "max": 100, "min": 0},
+            "ct": {"value": 4000, "max": 6500, "min": 1200},
+            "colorMode": "effect",
+        },
+        "effects": {"effectsList": ["Nemo", "Snowfall"], "select": "Snowfall"},
+        "panelLayout": {"layout": {"positionData": position_data}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_digital_twin_sync_through_real_transport():
+    position_data = [
+        {"panelId": 10, "x": 0, "y": 0, "o": 0},
+        {"panelId": 20, "x": 1, "y": 0, "o": 0},
+    ]
+    nl, session = _make(
+        {
+            ("get", ""): lambda: FakeResponse(payload=_full_info(position_data)),
+            ("put", "effects"): _NO_CONTENT,
+        }
+    )
+    twin = await DigitalTwin.create(nl)
+    assert twin.ids == [10, 20]
+    await twin.set_color(10, (255, 0, 0))
+    await twin.sync(transition_ms=50)
+
+    body = session.last("put", "effects")["write"]
+    assert body["command"] == "display"
+    assert body["animType"] == "static"
+    # Panel 10 should carry the red colour we set.
+    parts = list(map(int, body["animData"].split()))
+    assert parts[0] == 2  # two panels in the scene
+    assert parts[1:8] == [10, 1, 255, 0, 0, 0, 50]

--- a/tests/test_nanoleaf_transport.py
+++ b/tests/test_nanoleaf_transport.py
@@ -24,6 +24,9 @@ that wire the high-level helper clients (:class:`EffectsClient`,
 device is required.
 """
 
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-few-public-methods,unused-argument,protected-access
+
 import json
 
 try:
@@ -70,7 +73,9 @@ class FakeResponse:
         return self._payload
 
 
-_NO_CONTENT = lambda: FakeResponse(status=204, content_length=0)  # noqa: E731
+def _no_content():
+    """Factory for a 204 No Content response."""
+    return FakeResponse(status=204, content_length=0)
 
 
 class FakeSession:
@@ -126,14 +131,14 @@ async def test_get_json_returns_payload():
 
 @pytest.mark.asyncio
 async def test_put_json_handles_no_content():
-    nl, session = _make({("put", "state"): _NO_CONTENT})
+    nl, session = _make({("put", "state"): _no_content})
     assert await nl._put_json("state", {"on": {"value": True}}) is None
     assert session.last("put", "state") == {"on": {"value": True}}
 
 
 @pytest.mark.asyncio
 async def test_write_effect_wraps_payload_and_targets_effects():
-    nl, session = _make({("put", "effects"): _NO_CONTENT})
+    nl, session = _make({("put", "effects"): _no_content})
     await nl.write_effect({"command": "display", "animType": "static"})
     assert session.last("put", "effects") == {
         "write": {"command": "display", "animType": "static"}
@@ -151,7 +156,7 @@ async def test_effects_client_through_real_transport():
         {
             ("get", "effects/effectsList"): lambda: FakeResponse(payload=["A", "B"]),
             ("get", "effects/select"): lambda: FakeResponse(payload="B"),
-            ("put", "effects"): _NO_CONTENT,
+            ("put", "effects"): _no_content,
         }
     )
     client = EffectsClient(nl)
@@ -168,7 +173,7 @@ async def test_layout_client_through_real_transport():
             ("get", "panelLayout/globalOrientation"): lambda: FakeResponse(
                 payload={"value": 90}
             ),
-            ("put", "panelLayout/globalOrientation"): _NO_CONTENT,
+            ("put", "panelLayout/globalOrientation"): _no_content,
         }
     )
     client = LayoutClient(nl)
@@ -184,7 +189,7 @@ async def test_rhythm_client_through_real_transport():
             ("get", "rhythm"): lambda: FakeResponse(
                 payload={"rhythmActive": True, "rhythmMode": 0}
             ),
-            ("put", "rhythm"): _NO_CONTENT,
+            ("put", "rhythm"): _no_content,
         }
     )
     client = RhythmClient(nl)
@@ -229,7 +234,7 @@ async def test_digital_twin_sync_through_real_transport():
     nl, session = _make(
         {
             ("get", ""): lambda: FakeResponse(payload=_full_info(position_data)),
-            ("put", "effects"): _NO_CONTENT,
+            ("put", "effects"): _no_content,
         }
     )
     twin = await DigitalTwin.create(nl)


### PR DESCRIPTION
## Summary

Consolidates the open branches and makes the fork's new functionality actually
work against real hardware.

The headline finding: `EffectsClient`, `LayoutClient`, `RhythmClient` and
`DigitalTwin` were written against a `_get_json` / `_put_json` / `write_effect`
interface that the real `Nanoleaf` class **never implemented** (it only had
`_request`). The unit tests used mocks that *did* implement those methods, so
they passed while the features would have failed on a real device. This PR wires
the helpers to the real transport and adds tests that prove it end-to-end.

## Branch consolidation
- **PR #1** (`codex/find-and-fix-a-bug-in-codebase`) was already merged into
  `master`; it is the older upstream lineage and `master` supersedes it.
- **PR #2** (`codex/review-fork-for-major-issues`) is **merged here** — built-in
  asyncio pytest support (`conftest.py`) and removal of the orphaned
  `asyncio_mode` flag.

## Fixes
- **Remove dead duplicate `Nanoleaf` class** in `nanoleaf.py` that referenced
  undefined attributes (`self._base`, `self._token`). This broke `flake8`
  (`F811`) and `mypy`, i.e. **CI was red on `master`**.
- **Add `Nanoleaf._get_json` / `_put_json` / `write_effect`** (built on
  `_request`, so they inherit auth/retries/error handling).
- **`DigitalTwin.create()` now works on real devices** — `Nanoleaf.panels`
  returns a `set`, which the layout-discovery fallback previously rejected.
- **IPv6**: `_api_url` now uses the existing `_format_host_for_url` helper.
- **Touch stream**: `2 ^ 16` (XOR → 18) corrected to the `0xFFFF` "no second
  panel" sentinel in `events.py`.
- **Export `EffectsClient`** from the package.

## Tooling
- `mypy` config so the optional `aiohttp` import doesn't fail lint-only runs.
- CI now runs `pytest` (it never did before) on Python 3.11–3.13.
- Version `0.3.1 → 0.4.0`; README documents the helper clients.

## Testing
- `pytest -q` → 14 passed (incl. new `tests/test_nanoleaf_transport.py`, which
  drives the helpers and Digital Twin through a fake `aiohttp` session).
- `flake8` clean, `mypy` clean.

See `DECISIONS.md` for the full rationale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1jx1ChEXWfVfYqQjpYHL)_