### PR TITLE
Add music-sync effect discovery, rhythm/mic detection, and broaden hardware tolerance (0.5.0)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -78,3 +78,18 @@ the helper clients and Digital Twin through a fake `aiohttp` session),
 - No behavioural change to `authorize()` — the HA `config_flow` depends on its
   current exception contract (`Unauthorized` / `Unavailable`).
 - No hard dependency added on `pytest-asyncio` (the conftest covers both cases).
+
+## Follow-up: music-sync & broader hardware support (0.5.0)
+
+- `EffectsClient.get_effects_detail()` / `get_rhythm_effects()` — discover
+  sound-reactive effects via `PUT /effects {"write": {"command": "requestAll"}}`,
+  filtering `pluginType == "rhythm"` (confirmed against the Nanoleaf OpenAPI and
+  the openHAB / rowak implementations). Best-effort: returns `[]` if a device or
+  firmware answers in a different shape, so callers degrade gracefully.
+- `RhythmClient.is_connected()` / `get_aux_available()` — expose mic/sound-module
+  presence and aux availability (answers "does this device have a mic?").
+- `get_info()` now tolerates devices that omit `panelLayout` (no `KeyError`), so
+  non-panel / unusually-shaped responses don't break setup.
+- Unit-tested with mocked `requestAll`/`rhythm` responses through the real
+  transport. Not verifiable on hardware here, so the effect-discovery feature is
+  documented as best-effort.

--- a/README.md
+++ b/README.md
@@ -84,11 +84,18 @@ angle = await layout.get_global_orientation()        # int degrees (0..360)
 await layout.set_global_orientation(180)
 ```
 
-## Rhythm / audio module
+## Rhythm / audio module (music sync)
 ```python
-from aionanoleaf import RhythmClient
+from aionanoleaf import EffectsClient, RhythmClient
 
 rhythm = RhythmClient(light)
-if await rhythm.is_active():
-    await rhythm.set_mode("aux")  # or "microphone" / 0 / 1
+if await rhythm.is_connected():            # a sound module / mic is present
+    aux = await rhythm.get_aux_available()  # 3.5mm aux input present?
+    await rhythm.set_mode("microphone")     # or "aux" / 0 / 1
+    print("listening:", await rhythm.is_active())
+
+# Discover the sound-reactive ("music sync") effects, then select one:
+effects = EffectsClient(light)
+for name in await effects.get_rhythm_effects():  # pluginType == "rhythm"
+    print("music effect:", name)
 ```

--- a/aionanoleaf/effects.py
+++ b/aionanoleaf/effects.py
@@ -32,6 +32,39 @@ class EffectsClient:
             return str(data["select"])
         return ""
 
+    async def get_effects_detail(self) -> list[dict]:
+        """Return full metadata for every stored effect.
+
+        Issues ``PUT /effects`` with the ``requestAll`` command and returns the
+        ``animations`` list. Each item includes ``animName`` and, for plugin
+        effects, ``pluginType``. Returns ``[]`` if the device/firmware does not
+        answer in the expected shape.
+        """
+        # pylint: disable=protected-access
+        data = await self._nl._put_json(  # type: ignore[attr-defined]
+            "/effects", {"write": {"command": "requestAll"}}
+        )
+        if isinstance(data, dict):
+            anims = data.get("animations")
+            if isinstance(anims, list):
+                return [a for a in anims if isinstance(a, dict)]
+        return []
+
+    async def get_rhythm_effects(self) -> list[str]:
+        """Return the names of sound-reactive (rhythm) effects.
+
+        A rhythm effect is a plugin effect whose ``pluginType`` is ``"rhythm"``;
+        these react to audio captured by the device's microphone (or aux input),
+        i.e. they are the "music sync" effects.
+        """
+        names: list[str] = []
+        for anim in await self.get_effects_detail():
+            if anim.get("pluginType") == "rhythm":
+                name = anim.get("animName")
+                if isinstance(name, str):
+                    names.append(name)
+        return names
+
     async def select_effect(self, name: str) -> None:
         """Select an existing effect by name."""
         # pylint: disable=protected-access

--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -360,7 +360,12 @@ class Nanoleaf:
         self._color_mode = data["state"]["colorMode"]
         self._effects_list = data["effects"]["effectsList"]
         self._effect = data["effects"]["select"]
-        self._panels = {Panel(panel) for panel in data["panelLayout"]["layout"]["positionData"]}
+        # Panel devices report a layout; tolerate devices/firmware that omit it.
+        try:
+            position_data = data["panelLayout"]["layout"]["positionData"]
+        except (KeyError, TypeError):
+            position_data = []
+        self._panels = {Panel(panel) for panel in position_data}
 
     async def set_state(
         self,

--- a/aionanoleaf/rhythm.py
+++ b/aionanoleaf/rhythm.py
@@ -48,6 +48,16 @@ class RhythmClient:
             return val.lower() in ("1", "true", "yes", "on")
         return False
 
+    async def is_connected(self) -> bool:
+        """Return /rhythm.rhythmConnected (whether a sound module is present)."""
+        info = await self.get_info()
+        return bool(info.get("rhythmConnected"))
+
+    async def get_aux_available(self) -> bool:
+        """Return /rhythm.auxAvailable (whether the 3.5mm aux input exists)."""
+        info = await self.get_info()
+        return bool(info.get("auxAvailable"))
+
     async def get_mode(self) -> Optional[int]:
         """Return /rhythm.rhythmMode as int if present."""
         info = await self.get_info()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="aionanoleaf",
-    version="0.4.0",
+    version="0.5.0",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",
     description="Async Python package for the Nanoleaf API",

--- a/tests/test_nanoleaf_transport.py
+++ b/tests/test_nanoleaf_transport.py
@@ -199,6 +199,46 @@ async def test_rhythm_client_through_real_transport():
     assert session.last("put", "rhythm") == {"rhythmMode": 1}
 
 
+@pytest.mark.asyncio
+async def test_rhythm_connected_and_aux():
+    nl, _ = _make(
+        {
+            ("get", "rhythm"): lambda: FakeResponse(
+                payload={"rhythmConnected": True, "auxAvailable": False}
+            ),
+        }
+    )
+    client = RhythmClient(nl)
+    assert await client.is_connected() is True
+    assert await client.get_aux_available() is False
+
+
+@pytest.mark.asyncio
+async def test_rhythm_effects_discovery():
+    animations = {
+        "animations": [
+            {"animName": "Flames", "pluginType": "color"},
+            {"animName": "Pulse Pop Beats", "pluginType": "rhythm"},
+            {"animName": "Streaking Notes", "pluginType": "rhythm"},
+            {"animName": "Nemo"},  # no pluginType
+        ]
+    }
+    nl, session = _make({("put", "effects"): lambda: FakeResponse(payload=animations)})
+    client = EffectsClient(nl)
+    assert await client.get_rhythm_effects() == ["Pulse Pop Beats", "Streaking Notes"]
+    # requestAll is sent as a write command.
+    assert session.last("put", "effects") == {"write": {"command": "requestAll"}}
+
+
+@pytest.mark.asyncio
+async def test_get_info_tolerates_missing_panel_layout():
+    info = _full_info([])
+    del info["panelLayout"]  # e.g. a non-panel / unexpected device shape
+    nl, _ = _make({("get", ""): lambda: FakeResponse(payload=info)})
+    await nl.get_info()  # must not raise
+    assert nl.panels == set()
+
+
 # --------------------------------------------------------------------------- #
 # Digital twin end-to-end against the real transport
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Library support for the two follow-up requests on the HA side ("support all
hardware versions" and "wire up music sync").

## Added
- **`EffectsClient.get_effects_detail()` / `get_rhythm_effects()`** — discover
  the device's sound-reactive ("music sync") effects via
  `PUT /effects {"write": {"command": "requestAll"}}`, filtering
  `pluginType == "rhythm"` (confirmed against the Nanoleaf OpenAPI and the
  openHAB / rowak implementations). Best-effort: returns `[]` if a device or
  firmware answers in a different shape.
- **`RhythmClient.is_connected()` / `get_aux_available()`** — detect the
  presence of a microphone/sound module and a 3.5mm aux input (answers "does
  this device have a mic?").

## Changed
- **`get_info()`** now tolerates devices that omit `panelLayout` (no `KeyError`),
  improving robustness across hardware/firmware variants.
- Version `0.4.0 → 0.5.0`; README documents the music-sync helpers.

## Testing
`pytest -q` → 17 passed (new tests drive `get_rhythm_effects`, the rhythm
helpers and the defensive `get_info` through the real `Nanoleaf` transport with a
fake aiohttp session). `flake8`, `mypy` and `pylint` (10.00/10) all clean.

Effect discovery can't be verified on hardware from here, so it's documented as
best-effort. See `DECISIONS.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1jx1ChEXWfVfYqQjpYHL)_